### PR TITLE
Support method declarations of interfaces

### DIFF
--- a/ALObjectParser.Library/Helpers/ALMethodHelper.cs
+++ b/ALObjectParser.Library/Helpers/ALMethodHelper.cs
@@ -39,16 +39,19 @@ namespace ALObjectParser.Library
                             break;
                     }
 
-                    writer.WriteLine($"{(method.IsLocal ? "local " : "")}{methodType} {(method.Name.Contains(" ") ? $"\"{method.Name}\"": method.Name)}({parameterTxt}){(method.ReturnTypeDefinition != null ? ": " + method.ReturnTypeDefinition.Name : "")}");
+                    writer.WriteLine($"{(method.IsLocal ? "local " : "")}{methodType} {(method.Name.Contains(" ") ? $"\"{method.Name}\"" : method.Name)}({parameterTxt}){(method.ReturnTypeDefinition != null ? ": " + method.ReturnTypeDefinition.Name : "")}{(method.IsMethodDeclaration ? ";" : "")}");
 
-                    if (String.IsNullOrEmpty(method.Content))
+                    if (!method.IsMethodDeclaration)
                     {
-                        writer.WriteLine("begin");
-                        writer.WriteLine("end;");
-                    }
-                    else
-                    {
-                        writer.WriteLine(method.Content);
+                        if (String.IsNullOrEmpty(method.Content))
+                        {
+                            writer.WriteLine("begin");
+                            writer.WriteLine("end;");
+                        }
+                        else
+                        {
+                            writer.WriteLine(method.Content);
+                        }
                     }
 
                     writer.Indent--;

--- a/ALObjectParser.Library/Models/ALObjectParts/ALMethod.cs
+++ b/ALObjectParser.Library/Models/ALObjectParts/ALMethod.cs
@@ -14,6 +14,7 @@ namespace ALObjectParser.Library
         public string Name { get; set; }
         public ALMethodKind MethodKind { get; set; }
         public bool TestMethod { get; set; }
+        public bool IsMethodDeclaration { get; set; }
         public bool IsLocal { get; set; }
         public ICollection<ALParameter> Parameters { get; set; }
         public ALReturnTypeDefinition ReturnTypeDefinition { get; set; }

--- a/ALObjectParser.Library/Readers/ALObjectReaderBase.cs
+++ b/ALObjectParser.Library/Readers/ALObjectReaderBase.cs
@@ -70,8 +70,8 @@ namespace ALObjectParser.Library
             return Read(Lines);
         }
 
-        public T Read<T>(string Path) 
-            where T: ALObject
+        public T Read<T>(string Path)
+            where T : ALObject
         {
             var Lines = File.ReadAllLines(Path);
             IALObject result = Read(Lines);
@@ -114,7 +114,7 @@ namespace ALObjectParser.Library
         {
             var contents = Lines.ToList();
             var headerLines = GetObjectHeaderLines(contents);
-            var headers = headerLines                
+            var headers = headerLines
                 .Select(s => contents.IndexOf(s))
                 .ToList();
 
@@ -125,7 +125,7 @@ namespace ALObjectParser.Library
 
             var result = new List<IEnumerable<string>>();
             var c = headers.Count();
-            for (int i = 0; i < c; i++)    
+            for (int i = 0; i < c; i++)
             {
                 var startIndex = headers[i];
                 var endIndex = Lines.Count();
@@ -135,7 +135,7 @@ namespace ALObjectParser.Library
                     endIndex = headers[j];
                 }
 
-                result.Add(contents.GetRange(startIndex, endIndex-startIndex));
+                result.Add(contents.GetRange(startIndex, endIndex - startIndex));
             }
 
             return result;
@@ -144,7 +144,7 @@ namespace ALObjectParser.Library
         public IEnumerable<string> GetObjectHeaderLines(IEnumerable<string> Lines)
         {
             var headers = Lines
-                .Where(w => Regex.IsMatch(w.ToLower(), ObjectHeaderPattern, RegexOptions.IgnoreCase | RegexOptions.Multiline));               
+                .Where(w => Regex.IsMatch(w.ToLower(), ObjectHeaderPattern, RegexOptions.IgnoreCase | RegexOptions.Multiline));
 
             return headers;
         }
@@ -257,6 +257,10 @@ namespace ALObjectParser.Library
             {
                 return;
             }
+            if (Target is IALObject && ((IALObject)Target).Type == ALObjectType.@interface)
+            {
+                return; //An interface has no procedures. There are just procedure declarations
+            }
 
             Target.Methods = procedures
             .Select(s =>
@@ -363,7 +367,8 @@ namespace ALObjectParser.Library
             for (int i = 0; i < c; i++)
             {
                 var line = Lines.ElementAt(i);
-                if (Regex.IsMatch(line, pattern)) {
+                if (Regex.IsMatch(line, pattern))
+                {
 
                     var comment = new ALComment
                     {
@@ -399,13 +404,14 @@ namespace ALObjectParser.Library
                 section.Sections = GetSections(contents);
 
                 var subContents = contents;
-                section.Sections.ToList().ForEach(f => {
+                section.Sections.ToList().ForEach(f =>
+                {
                     subContents = subContents.Replace(f.TextContent, "");
                 });
 
                 var lines = subContents.Split("\r\n");
                 GetObjectProperties(lines, section);
-                GetMethods(lines, section);                
+                GetMethods(lines, section);
                 result.Add(section);
             }
 


### PR DESCRIPTION
If in interfaces two method declarations were added directly behind each other then there was an error in the ALObjectReaderBase in the line with the following statement
`var bodyLines = txtLines.GetRange(start, end - start - 1);`
because end and start had the same value. (because start is increment by 1 directly)

Now I added a property on the ALMethod which says that it's just a method declaration which will never have a body. Hope that's fine also for your other projects